### PR TITLE
modified zip file size to 2,147,483,647 which is 2^31-1. this allows …

### DIFF
--- a/src/main/java/com/checkmarx/jenkins/CxConfig.java
+++ b/src/main/java/com/checkmarx/jenkins/CxConfig.java
@@ -24,7 +24,7 @@ public class CxConfig {
 			configuration.loadFromXML(inputStream);
 			inputStream.close();
 		} catch (Exception e) {
-			configuration.setProperty(CONFIGURATION_MAX_ZIP_SIZE_KEY, "209715200");
+			configuration.setProperty(CONFIGURATION_MAX_ZIP_SIZE_KEY, "2147483647");
 		}
 	}
 

--- a/src/main/resources/com/checkmarx/jenkins/cxconfig.xml
+++ b/src/main/resources/com/checkmarx/jenkins/cxconfig.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!DOCTYPE properties SYSTEM "http://java.sun.com/dtd/properties.dtd">
 <properties>
-    <entry key="MaxZipSizeBytes">209715200</entry>
+    <entry key="MaxZipSizeBytes">2147483647</entry>
     <entry key="DefaultFilterPattern">
 !**/_cvs/**/*, !**/.svn/**/*,   !**/.hg/**/*,   !**/.git/**/*,  !**/.bzr/**/*, !**/bin/**/*,
 !**/obj/**/*,  !**/backup/**/*, !**/.idea/**/*, !**/*.DS_Store, !**/*.ipr,     !**/*.iws,


### PR DESCRIPTION
The current "209715200" is an arbitrary number and the plugin supports up to "2147483647." Tested this in Jenkins and Checkmarx (IIS with modified maximum upload size) and it works successfully. 

See the following link for full write up: http://www.th3r3p0.com/debugging/checkmarx+jenkins+plugin.html
