### PR TITLE
Fix casing of resolver service URL

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 description = Provides automatic scan of code by Checkmarx server and shows results summary and trend in Jenkins interface.
 group = com.checkmarx.jenkins
-version = 8.5.0-SNAPSHOT
+version = 8.6.0-SNAPSHOT
 repositoryVersion=
 
 org.gradle.daemon = false

--- a/src/main/java/com/checkmarx/jenkins/CxWebService.java
+++ b/src/main/java/com/checkmarx/jenkins/CxWebService.java
@@ -47,7 +47,7 @@ public class CxWebService {
 
     private static final String CHECKMARX_SERVER_WAS_NOT_FOUND_ON_THE_SPECIFIED_ADRESS = "Checkmarx server was not found on the specified adress";
     private static final int WEBSERVICE_API_VERSION = 1;
-    private static final String CXWSRESOLVER_PATH = "/cxwebinterface/cxwsresolver.asmx";
+    private static final String CXWSRESOLVER_PATH = "/CxWebInterface/cxwsresolver.asmx";
     private static final int LCID = 1033; // English
     private static final int MILISECONDS_IN_MINUTE = 1000 * 60;
 


### PR DESCRIPTION
A lower case URL produces a Runtime Error whereas the camel case version shows the proper resolver service description.