### PR TITLE
presetSpecified never being set?

### DIFF
--- a/src/main/java/com/checkmarx/jenkins/CxScanBuilder.java
+++ b/src/main/java/com/checkmarx/jenkins/CxScanBuilder.java
@@ -520,6 +520,7 @@ public class CxScanBuilder extends Builder implements SimpleBuildStep {
 
     @DataBoundSetter
     public void setPresetSpecified(boolean presetSpecified) {
+        // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
         this.presetSpecified = presetSpecified;
     }
 


### PR DESCRIPTION
(This is an issue in the guise of a PR.)

It looks to me like `presetSpecified` is never being set to `true` even when a preset has been specified. Is it possible this is an oversight? If so, I can submit a real PR.

Thanks!