### PR TITLE
Added target _top to sast-code-viewer-link elements

### DIFF
--- a/src/main/resources/com/checkmarx/jenkins/CxProjectResult/jobMain.jelly
+++ b/src/main/resources/com/checkmarx/jenkins/CxProjectResult/jobMain.jelly
@@ -1412,7 +1412,7 @@
                                 <div class="full-downloads sast-downloads">
                                     <!--html-->
                                     <div class="report-link link-to-result">
-                                        <a class="pdf-report" id="sast-code-viewer-link">
+                                        <a class="pdf-report" id="sast-code-viewer-link" target="_top">
                                             <div class="link-to-result">
                                                 <div class="results-link-icon link-icon">
                                                     <svg xmlns="http://www.w3.org/2000/svg" width="12" height="14"

--- a/src/main/resources/com/checkmarx/jenkins/CxScanResult/summary.html
+++ b/src/main/resources/com/checkmarx/jenkins/CxScanResult/summary.html
@@ -1034,7 +1034,7 @@
                                         </div>
                                         <div class="detailed-report">
                                             <div class="full-downloads sast-downloads">
-                                                <div class="report-link link-to-result"><a class="pdf-report" id="sast-code-viewer-link">
+                                                <div class="report-link link-to-result"><a class="pdf-report" id="sast-code-viewer-link" target="_top">
                                                     <div class="link-to-result">
                                                         <div class="results-link-icon link-icon">
                                                             <svg xmlns="http://www.w3.org/2000/svg" height="14" viewBox="0 0 12 14" width="12"><title>analize</title>

--- a/src/main/resources/com/checkmarx/jenkins/CxScanResult/summary.jelly
+++ b/src/main/resources/com/checkmarx/jenkins/CxScanResult/summary.jelly
@@ -1392,7 +1392,7 @@
                                 <div class="full-downloads sast-downloads">
                                     <!--html-->
                                     <div class="report-link link-to-result">
-                                        <a class="pdf-report" id="sast-code-viewer-link">
+                                        <a class="pdf-report" id="sast-code-viewer-link" target="_top">
                                             <div class="link-to-result">
                                                 <div class="results-link-icon link-icon">
                                                     <svg xmlns="http://www.w3.org/2000/svg" width="12" height="14"

--- a/src/main/resources/com/checkmarx/jenkins/ui-template/summary-section.html
+++ b/src/main/resources/com/checkmarx/jenkins/ui-template/summary-section.html
@@ -573,7 +573,7 @@
                     </div>
                     <!--code viewer-->
                     <div class="report-link">
-                        <a id="sast-code-viewer-link" class="pdf-report">
+                        <a id="sast-code-viewer-link" class="pdf-report" target="_top">
                             <div class="pdf-report download-icon">
                                 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:svgjs="http://svgjs.com/svgjs"
                                      id="SvgjsSvg1041" version="1.1" width="15" height="13" viewBox="0 0 15 13"><title>Icon</title>


### PR DESCRIPTION
When using the [Jenkins HTML Publisher plugin](https://github.com/jenkinsci/htmlpublisher-plugin), the HTML report is rendered in an iframe. The report's links to the CxSAST Code Viewer can be blocked when servers send an `X-Frame-Options: SAMEORIGIN` header.

This change opens links to the CxSAST Code Viewer in the full window so that users can access the viewer regardless of how the HTML report was rendered.