### PR TITLE
Add the option to return success on error

### DIFF
--- a/src/main/java/com/checkmarx/jenkins/JobGlobalStatusOnError.java
+++ b/src/main/java/com/checkmarx/jenkins/JobGlobalStatusOnError.java
@@ -2,7 +2,7 @@ package com.checkmarx.jenkins;
 
 public enum JobGlobalStatusOnError {
 
-	FAILURE("Failure"), UNSTABLE("Unstable");
+	FAILURE("Failure"), UNSTABLE("Unstable"), SUCCESS("Success");
 
 	private final String displayName;
 


### PR DESCRIPTION
This is to ensure build success regardless of Checkmarx scan status.

Use case: Communication errors or other errors on the Checkmarx server preventing builds from completing thus being a blocker for release dates regardless of vulnerability threat/risk level.