### PR TITLE
Update JobStatusOnError.java

### DIFF
--- a/src/main/java/com/checkmarx/jenkins/JobStatusOnError.java
+++ b/src/main/java/com/checkmarx/jenkins/JobStatusOnError.java
@@ -1,7 +1,7 @@
 package com.checkmarx.jenkins;
 
 public enum JobStatusOnError {
-	GLOBAL("Use Global Settings"), FAILURE("Failure"), UNSTABLE("Unstable");
+	GLOBAL("Use Global Settings"), FAILURE("Failure"), UNSTABLE("Unstable") SUCCESS("Success");
 
 	private final String displayName;
 


### PR DESCRIPTION
This is to ensure build success regardless of Checkmarx scan status.

Use case: Communication errors or other errors on the Checkmarx server preventing builds from completing thus being a blocker for release dates regardless of vulnerability threat/risk level.