### PR TITLE
[JENKINS-63019] Add serverUrl to ProxyHelper.getProxyConfig + consider no proxy hosts…

### DIFF
--- a/src/main/java/com/checkmarx/jenkins/CommonClientFactory.java
+++ b/src/main/java/com/checkmarx/jenkins/CommonClientFactory.java
@@ -20,7 +20,7 @@ class CommonClientFactory {
                 SCAN_ORIGIN,
                 !enableCertificateValidation);
 
-        scanConfig.setProxyConfig(ProxyHelper.getProxyConfig());
+        scanConfig.setProxyConfig(ProxyHelper.getProxyConfig(credentials.getServerUrl()));
 
         return getInstance(scanConfig, log);
     }

--- a/src/main/java/com/checkmarx/jenkins/CxScanBuilder.java
+++ b/src/main/java/com/checkmarx/jenkins/CxScanBuilder.java
@@ -789,14 +789,15 @@ public class CxScanBuilder extends Builder implements SimpleBuildStep {
     private CxScanConfig resolveConfiguration(Run<?, ?> run, DescriptorImpl descriptor, EnvVars env, CxLoggerAdapter log) {
         CxScanConfig ret = new CxScanConfig();
 
+        CxCredentials cxCredentials = CxCredentials.resolveCred(this, descriptor, run);
+
         //general
         ret.setCxOrigin(REQUEST_ORIGIN);
         ret.setDisableCertificateValidation(!descriptor.isEnableCertificateValidation());
-        ret.setProxyConfig(ProxyHelper.getProxyConfig());
+        ret.setProxyConfig(ProxyHelper.getProxyConfig(cxCredentials.getServerUrl().trim()));
         ret.setMvnPath(descriptor.getMvnPath());
 
         //cx server
-        CxCredentials cxCredentials = CxCredentials.resolveCred(this, descriptor, run);
         ret.setUrl(cxCredentials.getServerUrl().trim());
         ret.setUsername(cxCredentials.getUsername());
         ret.setPassword(Aes.decrypt(cxCredentials.getPassword(), cxCredentials.getUsername()));
@@ -1584,7 +1585,7 @@ public class CxScanBuilder extends Builder implements SimpleBuildStep {
                 scaConfig.setRemoteRepositoryInfo(null);
                 config.setScaConfig(scaConfig);
 
-                ProxyConfig proxyConfig = ProxyHelper.getProxyConfig();
+                ProxyConfig proxyConfig = ProxyHelper.getProxyConfig(scaServerUrl);
                 config.setProxyConfig(proxyConfig);
 
                 CxShragaClient.testScaConnection(config, serverLog);

--- a/src/main/java/com/checkmarx/jenkins/ProxyHelper.java
+++ b/src/main/java/com/checkmarx/jenkins/ProxyHelper.java
@@ -1,5 +1,7 @@
 package com.checkmarx.jenkins;
 
+import java.net.Proxy;
+
 import com.cx.restclient.dto.ProxyConfig;
 import hudson.ProxyConfiguration;
 import jenkins.model.Jenkins;
@@ -9,7 +11,7 @@ class ProxyHelper {
      * Gets proxy settings defined globally for current Jenkins instance.
      * @return Jenkins proxy settings converted to an internal object.
      */
-    static ProxyConfig getProxyConfig() {
+    static ProxyConfig getProxyConfig(String serverUrl) {
         ProxyConfig internalProxy = null;
         Jenkins instance = Jenkins.getInstance();
 
@@ -18,11 +20,14 @@ class ProxyHelper {
         // noinspection ConstantConditions
         if (instance != null && instance.proxy != null) {
             ProxyConfiguration jenkinsProxy = instance.proxy;
-            internalProxy = new ProxyConfig();
-            internalProxy.setHost(jenkinsProxy.name);
-            internalProxy.setPort(jenkinsProxy.port);
-            internalProxy.setUsername(jenkinsProxy.getUserName());
-            internalProxy.setPassword(jenkinsProxy.getPassword());
+            Proxy proxy = jenkinsProxy.createProxy(serverUrl);
+            if (proxy != Proxy.NO_PROXY) {
+                internalProxy = new ProxyConfig();
+                internalProxy.setHost(jenkinsProxy.name);
+                internalProxy.setPort(jenkinsProxy.port);
+                internalProxy.setUsername(jenkinsProxy.getUserName());
+                internalProxy.setPassword(jenkinsProxy.getPassword());
+            }
         }
         return internalProxy;
     }


### PR DESCRIPTION
@see [JENKINS-63019](https://issues.jenkins-ci.org/browse/JENKINS-63019)

Actually, the plugin-checkmarx not consider No Proxy hosts defined in Jenkins Proxy configuration.
So, the plugin try to connect with the proxy even if the Checkmarx server doesn't need it.

This PR use hudson.ProxyConfiguration.createProxy to consider No Proxy hosts defined in Jenkins configuration.
