### PR TITLE
Add teamPath support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ dependencies {
     compileOnly 'com.intellij:annotations:12.0',
             'org.slf4j:slf4j-api:1.6.1'
 
-    compile 'com.checkmarx:cx-client-common:2020.2.20.SCA'
+    compile 'com.checkmarx:cx-client-common:2020.2.21.SCA'
 
     optionalJenkinsPlugins 'org.jenkins-ci.main:maven-plugin:1.509.4@jar',
             'org.jenkins-ci.plugins:credentials:2.1.19@jar'


### PR DESCRIPTION
This pr gets teamPath value given from job config and sets it to `teamPath` header on API requests to be later used for advanced header based routing. Supported system will be able to reroute requests by their header in a multi-SAST environment.