### PR TITLE
"Enable synchronous Scan" missing fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,7 @@ dependencies {
         exclude group: 'org.apache.logging.log4j', module: 'log4j-core'
     }
 
-    compile 'com.checkmarx:cx-client-common:2021.3.166',
+    compile 'com.checkmarx:cx-client-common:2021.3.171',
             'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.10.5',
             'com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.10.5',
             'org.apache.logging.log4j:log4j-slf4j-impl:2.13.3',

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 description = Provides automatic scan of code by Checkmarx server and shows results summary and trend in Jenkins interface.
 group = com.checkmarx.jenkins
-version = 2021.3.2
+version = 2021.3.3
 
 repositoryVersion=
 

--- a/src/main/java/com/checkmarx/jenkins/CxScanBuilder.java
+++ b/src/main/java/com/checkmarx/jenkins/CxScanBuilder.java
@@ -1266,7 +1266,7 @@ public class CxScanBuilder extends Builder implements SimpleBuildStep {
         ret.setTeamId(groupId);
 
         //scan control
-        boolean isaAsync = !isWaitForResultsEnabled() && !(descriptor.isForcingVulnerabilityThresholdEnabled() && descriptor.isLockVulnerabilitySettings());
+        boolean isaAsync = !isWaitForResultsEnabled();
         ret.setSynchronous(!isaAsync);
         ret.setDenyProject(descriptor.isProhibitProjectCreation());
 

--- a/src/main/java/com/checkmarx/jenkins/CxScanBuilder.java
+++ b/src/main/java/com/checkmarx/jenkins/CxScanBuilder.java
@@ -732,7 +732,7 @@ public class CxScanBuilder extends Builder implements SimpleBuildStep {
     }
 
     @DataBoundSetter
-    public void setaddGlobalCommenToBuildCommet(boolean addGlobalCommenToBuildCommet) {
+    public void setAddGlobalCommenToBuildCommet(boolean addGlobalCommenToBuildCommet) {
         this.addGlobalCommenToBuildCommet = addGlobalCommenToBuildCommet;
     }
 
@@ -1915,6 +1915,7 @@ public class CxScanBuilder extends Builder implements SimpleBuildStep {
         private JobGlobalStatusOnError jobGlobalStatusOnError;
         private JobGlobalStatusOnError jobGlobalStatusOnThresholdViolation = JobGlobalStatusOnError.FAILURE;
         private boolean scanTimeOutEnabled;
+        private boolean globallyDefineScanSettings;
         private boolean continueBuildWhenTimedOut;
         private Integer scanTimeoutDuration; // In minutes.
         private boolean lockVulnerabilitySettings = true;
@@ -2125,7 +2126,14 @@ public class CxScanBuilder extends Builder implements SimpleBuildStep {
             this.continueBuildWhenTimedOut = continueBuildWhenTimedOut;
         }
         
+        public boolean getGloballyDefineScanSettings() {
+            return globallyDefineScanSettings;
+        }
 
+        public void setGloballyDefineScanSettings(boolean globallyDefineScanSettings) {
+            this.globallyDefineScanSettings = globallyDefineScanSettings;
+        }
+        
         @Nullable
         public Integer getScanTimeoutDuration() {
             return scanTimeoutDuration;
@@ -2771,8 +2779,12 @@ public class CxScanBuilder extends Builder implements SimpleBuildStep {
             // option.
             if (!pluginData.has(DEPENDENCY_SCAN_CONFIG_PROP)) {
                 pluginData.put(DEPENDENCY_SCAN_CONFIG_PROP, null);
+                
             }
-
+            // Have put the below line to fix AB # 493 - "Globally define dependency scan settings" selection is not retained. 
+            // Line pluginData.put(DEPENDENCY_SCAN_CONFIG_PROP, null); should have solved the problem but putting null is actually not working. JSONObject.NULL
+            // API also no more available
+            setGloballyDefineScanSettings(pluginData.has(DEPENDENCY_SCAN_CONFIG_PROP));
             req.bindJSON(this, pluginData);
             save();
             return super.configure(req, formData);

--- a/src/main/java/com/checkmarx/jenkins/CxScanBuilder.java
+++ b/src/main/java/com/checkmarx/jenkins/CxScanBuilder.java
@@ -1338,7 +1338,10 @@ public class CxScanBuilder extends Builder implements SimpleBuildStep {
             enableProjectPolicyEnforcement = false;
         }
         ret.setEnablePolicyViolations(enableProjectPolicyEnforcement);
-
+        // Set the Continue build flag to Configuration object if Option from UI is choosen as useContinueBuildOnError
+        if(useContinueBuildOnError(getDescriptor())) {
+        	ret.setContinueBuild(Boolean.TRUE);
+        }
         return ret;
     }
 
@@ -1534,6 +1537,7 @@ public class CxScanBuilder extends Builder implements SimpleBuildStep {
         log.info("SAST scan enabled: " + config.isSastEnabled());
         log.info("avoid duplicated projects scans: " + config.isAvoidDuplicateProjectScans());
         log.info("enable Project Policy Enforcement: " + config.getEnablePolicyViolations());
+        log.info("continue build when timed out: " + config.getContinueBuild());
 
         ScannerType scannerType = getDependencyScannerType(config);
         String dependencyScannerType = scannerType != null ? scannerType.getDisplayName() : "NONE";
@@ -1773,7 +1777,15 @@ public class CxScanBuilder extends Builder implements SimpleBuildStep {
                 || (JobStatusOnError.GLOBAL.equals(getJobStatusOnError()) && JobGlobalStatusOnError.UNSTABLE.equals(descriptor
                 .getJobGlobalStatusOnError()));
     }
-
+    /**
+     * Checks if job should fail with <code>UNSTABLE</code> status instead of <code>FAILED</code>
+     *
+     * @param descriptor Descriptor of the current build step
+     * @return if job should fail with <code>UNSTABLE</code> status instead of <code>FAILED</code>
+     */
+    private boolean useContinueBuildOnError(final DescriptorImpl descriptor) {
+        return descriptor.getContinueBuildWhenTimedOut();
+    }
     private boolean isThisBuildIncremental(int buildNumber) {
 
         boolean askedForIncremental = isIncremental();
@@ -1903,6 +1915,7 @@ public class CxScanBuilder extends Builder implements SimpleBuildStep {
         private JobGlobalStatusOnError jobGlobalStatusOnError;
         private JobGlobalStatusOnError jobGlobalStatusOnThresholdViolation = JobGlobalStatusOnError.FAILURE;
         private boolean scanTimeOutEnabled;
+        private boolean continueBuildWhenTimedOut;
         private Integer scanTimeoutDuration; // In minutes.
         private boolean lockVulnerabilitySettings = true;
 
@@ -2103,6 +2116,15 @@ public class CxScanBuilder extends Builder implements SimpleBuildStep {
         public void setScanTimeOutEnabled(boolean scanTimeOutEnabled) {
             this.scanTimeOutEnabled = scanTimeOutEnabled;
         }
+        
+        public boolean getContinueBuildWhenTimedOut() {
+            return continueBuildWhenTimedOut;
+        }
+
+        public void setContinueBuildWhenTimedOut(boolean continueBuildWhenTimedOut) {
+            this.continueBuildWhenTimedOut = continueBuildWhenTimedOut;
+        }
+        
 
         @Nullable
         public Integer getScanTimeoutDuration() {

--- a/src/main/resources/META-INF/hudson.remoting.ClassFilter
+++ b/src/main/resources/META-INF/hudson.remoting.ClassFilter
@@ -42,3 +42,6 @@ com.cx.restclient.ast.dto.sca.report.PolicyRule
 com.cx.restclient.ast.dto.sca.report.PolicyEvaluation
 com.cx.restclient.sast.dto.ResponseSastScanStatus
 com.cx.restclient.sast.dto.CxScanStateObj
+com.cx.restclient.sast.dto.CxDateAndTimeObj
+com.cx.restclient.sast.dto.CxLanguageObj
+com.cx.restclient.sast.dto.CxLinkObj

--- a/src/main/resources/com/checkmarx/jenkins/CxProjectResult/jobMain.jelly
+++ b/src/main/resources/com/checkmarx/jenkins/CxProjectResult/jobMain.jelly
@@ -29,16 +29,25 @@
                     vertical-align: top;
                     }
                 </style>
-                <div id="async-note">
-                    <div class="async-note"><div class="async-note-title">Note:</div>
-                        <div class="async-note-body" id="async-note-body">Job is configured to run Checkmarx scan asynchronously. Specific build scan result cannot be displayed in this mode</div></div>
-                </div>
+               
             </j:if>
             <j:if test="${result.isRemoveAsyncHtml()}">
+             	<div id="async-note">
+                    <div class="async-note"><div class="async-note-title">Note:</div>
+                        <div class="async-note-body" id="async-note-body">Job is configured to run Checkmarx scan asynchronously. Displayed results are of the previous successful scan.</div></div>
+                </div>
                 <div>
                     ${result.getHtmlReport()}
                 </div>
-            </j:if>
+            </j:if> 
+            
+            <j:if test="${!result.isRemoveAsyncHtml()}">
+             	<div id="async-note">
+                    <div class="async-note"><div class="async-note-title">Note:</div>
+                        <div class="async-note-body" id="async-note-body">Job is configured to run Checkmarx scan asynchronously.Report generation is disabled.</div></div>
+                </div>
+            </j:if> 
+            
         </j:forEach>
     </j:if>
 

--- a/src/main/resources/com/checkmarx/jenkins/CxScanBuilder/config.jelly
+++ b/src/main/resources/com/checkmarx/jenkins/CxScanBuilder/config.jelly
@@ -236,14 +236,21 @@
                 <f:entry title="Dependency scan low severity vulnerabilities threshold">
                     <f:readOnlyTextbox value="${descriptor.osaLowThresholdEnforcement}" />
                 </f:entry>
+				<f:optionalBlock title="Enable synchronous mode" inline="true" field="waitForResultsEnabled"
+                    checked="${instance==null?true:instance.waitForResultsEnabled}">
+
+                    <!-- -= Enable Synchronous Mode =- -->
+
+                    <f:description>Synchronous mode allows viewing scan results in Jenkins and setting thresholds
+                    </f:description>
 
                 <f:optionalBlock title="Generate CxSAST PDF report" inline="true" field="generatePdfReport" />
 
                 <!-- -= enableProjectPolicyEnforcement =- -->
                 <f:optionalBlock title="Enable Project's policy enforcement" inline="true" field="enableProjectPolicyEnforcement" />
-                 <!-- -= Generate Full XML report =- -->
-                  <f:optionalBlock title="Generate CxSAST full XML report" inline="true" field="generateXmlReport"
-                   checked="${instance==null?true:instance.generateXmlReport}" />
+                 
+                  
+                   </f:optionalBlock>
             </j:when>
 
             <!-- ** use specific configuration setting ** -->

--- a/src/main/resources/com/checkmarx/jenkins/CxScanBuilder/config.jelly
+++ b/src/main/resources/com/checkmarx/jenkins/CxScanBuilder/config.jelly
@@ -101,7 +101,7 @@
         <f:entry title="Source character encoding (configuration)" field="sourceEncoding" description="Default Configuration uses UTF-8">
             <f:select />
         </f:entry>
-            <f:optionalBlock title="Allow global comment" inline="true" field="addGlobalCommenToBuildCommet" checked="true"  />
+            <f:optionalBlock title="Allow global comment" inline="true" field="addGlobalCommenToBuildCommet"/>
         <f:entry title="Comment" field="comment">
             <f:textarea />
         </f:entry>

--- a/src/main/resources/com/checkmarx/jenkins/CxScanBuilder/global.jelly
+++ b/src/main/resources/com/checkmarx/jenkins/CxScanBuilder/global.jelly
@@ -110,6 +110,10 @@
                 <f:number clazz="positive-number" min="0" step="1" default="1"/>
             </f:entry>
         </f:optionalBlock>
+        
+        <f:optionalBlock title="Continue when timed out" inline="true" field="continueBuildWhenTimedOut">
+            
+        </f:optionalBlock>
 
         <f:optionalBlock title="Globally define dependency scan settings" field="dependencyScanConfig"
                          checked="${descriptor.dependencyScanConfig != null}">

--- a/src/main/resources/com/checkmarx/jenkins/CxScanBuilder/global.jelly
+++ b/src/main/resources/com/checkmarx/jenkins/CxScanBuilder/global.jelly
@@ -116,7 +116,7 @@
         </f:optionalBlock>
 
         <f:optionalBlock title="Globally define dependency scan settings" field="dependencyScanConfig"
-                         checked="${descriptor.dependencyScanConfig != null}">
+                         checked="${descriptor.globallyDefineScanSettings}">
             <f:entry title="Include/Exclude wildcard patterns" field="dependencyScanPatterns">
                 <f:textarea value="${descriptor.dependencyScanConfig.dependencyScanPatterns}" />
             </f:entry>

--- a/src/main/resources/com/checkmarx/jenkins/CxScanBuilder/help-continueBuildWhenTimedOut.html
+++ b/src/main/resources/com/checkmarx/jenkins/CxScanBuilder/help-continueBuildWhenTimedOut.html
@@ -1,0 +1,3 @@
+<div>
+    Enables the option to continue the build if scan time out happens. In this case last scan reports will be shown.
+</div>


### PR DESCRIPTION
To fix the existing plugin issue AB#2436, "Enable Synchronous scan" field was missing when at global configuration level, "Globally Define vulnerability thresholds for all jobs" and "Always use the defined global vulnerability thresholds" both options are selected. Even after fixing the UI visibility issue, scan was always running in synchronous mode even though "Enable Synchronous Mode" was deselected . And When "Generate XML Report" option was selected which was under "Enable Synchronous Scan" section, null pointer exception was getting thrown. To resolve that the UI field "Generate XML Report" option is removed