### PR TITLE
Update hudson.remoting.ClassFilter

### DIFF
--- a/src/main/resources/META-INF/hudson.remoting.ClassFilter
+++ b/src/main/resources/META-INF/hudson.remoting.ClassFilter
@@ -14,6 +14,7 @@ com.cx.restclient.dto.ScannerType
 com.cx.restclient.osa.dto.OSAScanState
 com.cx.restclient.osa.dto.OSASummaryResults
 com.cx.restclient.sast.dto.SASTResults
+com.cx.restclient.dto.Results
 com.cx.restclient.osa.dto.CVEReportTableRow
 com.cx.restclient.osa.dto.Library
 com.cx.restclient.osa.dto.CVE


### PR DESCRIPTION
Added Results class to the class filter as during deserialization this was failing. And it is serialized so as to work in master slave ode if during scan any exception occurs , the exception was not getting added to results object. Hence failTheBuild() in CxScanBuilder class not not making the build fail/unstable . This issue was discovered during defect AB#2334. The issue was even if user gives wrong user name and password, the job still continue to be SUCCESS in master slave mode
