### PR TITLE
Completed SCA time out feature after testing the code flow is coming to the bl…

### DIFF
--- a/src/main/java/com/checkmarx/jenkins/CxScanBuilder.java
+++ b/src/main/java/com/checkmarx/jenkins/CxScanBuilder.java
@@ -1496,6 +1496,7 @@ public class CxScanBuilder extends Builder implements SimpleBuildStep {
             config.setOsaRunInstall(effectiveConfig.osaInstallBeforeScan);
         } else if (config.isAstScaEnabled()) {
             config.setAstScaConfig(getScaConfig(run, env, dependencyScanConfig, descriptor));
+            config.setSCAScanTimeoutInMinutes(dependencyScanConfig.scaTimeout);
         }
     }
 
@@ -2473,6 +2474,7 @@ public class CxScanBuilder extends Builder implements SimpleBuildStep {
                                                   @QueryParameter String scaCredentialsId,
                                                   @QueryParameter String scaTenant,
                                                   @QueryParameter String scaTeamPath,
+                                                  @QueryParameter Integer scaTimeout,
                                                   @AncestorInPath Item item) {
             try {
                 CxScanConfig config = new CxScanConfig();
@@ -2496,6 +2498,7 @@ public class CxScanBuilder extends Builder implements SimpleBuildStep {
                 scaConfig.setRemoteRepositoryInfo(null);
                 config.setAstScaConfig(scaConfig);
                 config.addScannerType(ScannerType.AST_SCA);
+                config.setSCAScanTimeoutInMinutes(scaTimeout);
 
                 try {
                     Jenkins instance = Jenkins.getInstance();

--- a/src/main/java/com/checkmarx/jenkins/DependencyScanConfig.java
+++ b/src/main/java/com/checkmarx/jenkins/DependencyScanConfig.java
@@ -72,6 +72,9 @@ public class DependencyScanConfig {
     public String scaTeamPath;
     
     @DataBoundSetter
+    public Integer scaTimeout;
+    
+    @DataBoundSetter
     public boolean isIncludeSources;
     
     @DataBoundSetter

--- a/src/main/resources/com/checkmarx/jenkins/CxScanBuilder/config.jelly
+++ b/src/main/resources/com/checkmarx/jenkins/CxScanBuilder/config.jelly
@@ -184,8 +184,13 @@
                     <f:entry title="Teampath" field="scaTeamPath">
                         <f:textbox value="${instance.dependencyScanConfig.scaTeamPath}"/>
                     </f:entry>
+                    
+                    <f:entry title="SCA Scan timeout (minutes)" field="scaTimeout">
+                        <f:textbox value="${instance.dependencyScanConfig.scaTimeout}"/>
+                    </f:entry>
+                    
                     <f:validateButton title="Test Connection" progress="Testing..." method="testScaConnection"
-                                      with="scaServerUrl,scaAccessControlUrl,scaCredentialsId,scaTenant,scaTeamPath"/>
+                                      with="scaServerUrl,scaAccessControlUrl,scaCredentialsId,scaTenant,scaTeamPath,scaTimeout"/>
                    
                     <f:entry title="Package Manager's Config File(s) Path" field="scaConfigFile">
                         <f:textarea value="${instance.dependencyScanConfig.scaConfigFile}" />

--- a/src/main/resources/com/checkmarx/jenkins/CxScanBuilder/global.jelly
+++ b/src/main/resources/com/checkmarx/jenkins/CxScanBuilder/global.jelly
@@ -164,8 +164,11 @@
                     <f:entry title="Teampath" field="scaTeamPath">
                         <f:textbox value="${descriptor.dependencyScanConfig.scaTeamPath}"/>
                      </f:entry>   
+                     <f:entry title="SCA Scan timeout (minutes)" field="scaTimeout">
+                        <f:textbox value="${descriptor.dependencyScanConfig.scaTimeout}"/>
+                     </f:entry>
                     <f:validateButton title="Test Connection" progress="Testing..." method="testScaConnection"
-                                      with="scaServerUrl,scaAccessControlUrl,scaCredentialsId,scaTenant, scaTeamPath"/>
+                                      with="scaServerUrl,scaAccessControlUrl,scaCredentialsId,scaTenant,scaTeamPath,scaTimeout"/>
                 </f:nested>
                 <f:entry title="Package Manager's Config File(s) Path" field="scaConfigFile">
                         <f:textarea value="${descriptor.dependencyScanConfig.scaConfigFile}" />


### PR DESCRIPTION
Tested 2 scenarios

1. Enable dependency scan settings with SCA option. 
2. Give SCA time out value as 1 min.( try with both global as well as job level)
3. With a scan where SCA scan exceeded time limit- scan fails with error message
[Cx-Info]: Waiting for CxAST-SCA scan results. Elapsed time: 00:00:44. Status: Running.
ERROR: Build step failed with exception
org.awaitility.core.ConditionTimeoutException: Failed to perform CxAST-SCA scan. The scan has been automatically aborted: reached the user-specified timeout (1 minutes).
	at com.cx.restclient.ast.AstWaiter.waitForScanToFinish(AstWaiter.java:56)
	at com.cx.restclient.ast.AstClient.waitForScanToFinish(AstClient.java:145)
	at com.cx.restclient.ast.AstScaClient.waitForScanResults(AstScaClient.java:226)
4. Other within the timeout - scan passed