### PR TITLE
Remove broken build status icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
 # Checkmarx SAST plugin for Jenkins
 
-[![Build Status](https://jenkins.ci.cloudbees.com/job/plugins/job/checkmarx-plugin/badge/icon)](https://jenkins.ci.cloudbees.com/job/plugins/job/checkmarx-plugin/)
-
 For information about this plug-in check its [Wiki](https://wiki.jenkins-ci.org/display/JENKINS/Checkmarx+CxSAST+Plugin).
 


### PR DESCRIPTION
## Remove broken build status icon

User documentation is not helped by the build status icon and the referenced location no longer exists.
