### PR TITLE
Move documentation into the GitHub repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,4 +68,4 @@ For release notes see:
 
 For more information see:
 
--   [CxSAST Jenkins Plugin](https://checkmarx.atlassian.net/wiki/spaces/KC/pages/11337790/CxSAST+Jenkins+Plugin)
+-   [CxSAST Jenkins Plugin](https://checkmarx.atlassian.net/wiki/spaces/SD/pages/1339130110/Jenkins+Plugin)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,71 @@
 # Checkmarx SAST plugin for Jenkins
 
-[![Build Status](https://jenkins.ci.cloudbees.com/job/plugins/job/checkmarx-plugin/badge/icon)](https://jenkins.ci.cloudbees.com/job/plugins/job/checkmarx-plugin/)
+This plugin adds an ability to perform automatic code scan by Checkmarx
+server and shows results summary and trend in Jenkins interface.
 
-For information about this plug-in check its [Wiki](https://wiki.jenkins-ci.org/display/JENKINS/Checkmarx+CxSAST+Plugin).
+# Summary
 
+Checkmarx CxSAST is a unique source code analysis solution that provides
+tools for identifying, tracking, and repairing technical and logical
+flaws in the source code, such as security vulnerabilities, compliance
+issues, and business logic problems.
+
+Without needing to build or compile a software project's source code,
+CxSAST builds a logical graph of the code's elements and flows. CxSAST
+then queries this internal code graph. CxSAST comes with an extensive
+list of hundreds of preconfigured queries for known security
+vulnerabilities for each programming language. Using the CxSAST Auditor
+tool, you can configure your own additional queries for security, QA,
+and business logic purposes.
+
+CxSAST provides scan results either as static reports, or in an
+interactive interface that enables tracking runtime behavior per
+vulnerability through the code, and provides tools and guidelines for
+remediation. Results can be customized to eliminate false positives, and
+various types of workflow metadata can be added to each result instance.
+These metadata are maintained through subsequent scans, as long as the
+instance continues to be found.
+
+The input to CxSAST's scanning and analysis is the source code, not
+binaries, so no building or compiling is required, and no libraries need
+to be available. The code doesn't even need to be able to compile and
+link properly. Consequently, CxSAST can run scans and generate security
+reports at any given point in a software project's development life
+cycle.
+
+The CxSAST Jenkins plugin enables:
+
+-   Automatic code scan on CxSAST server, upon each build triggered by
+    Jenkins
+-   Ability to run Open Source Analysis (CxOSA) from within Jenkins
+-   Graphical Scan results summary and trends in Jenkins interface
+-   Links from Jenkins to CxSAST and CxOSA detailed scan results and to
+    PDF report
+
+After setting up the plugin, you can
+[configure](https://checkmarx.atlassian.net/wiki/display/KC/Configuring+a+Scan+Action)
+any Jenkins job with a build step action to activate a CxSAST scan. When
+a Job scan (build) is activated, Jenkins sends the job's source code to
+CxSAST, where it is scanned according to the parameters specified in the
+build step action. The scan results are stored in the CxSAST project
+specified in the action, and
+[displayed](https://checkmarx.atlassian.net/wiki/display/KC/Viewing+Scan+Results+in+Jenkins)
+in the Jenkins job.
+
+CxOSA for Jenkins can be run in cases where open source components are
+used as part of the development effort. When a CxOSA (build) is
+activated, Jenkins sends the open source fingerprints to the CxOSA
+service (note that no customer details or used libraries are passed to
+the CxOSA service). Using these open source fingerprints, the CxOSA
+service maps the open source libraries, identifies the vulnerabilities,
+analyses license risk and compliance, builds the inventory and detects
+outdated libraries. Comprehensive and summarized reports are generated
+within the Jenkins interface.
+
+For release notes see:
+
+-   [CxSAST Release Notes](https://checkmarx.atlassian.net/wiki/spaces/KC/pages/9142278/CxSAST+Release+Notes)
+
+For more information see:
+
+-   [CxSAST Jenkins Plugin](https://checkmarx.atlassian.net/wiki/spaces/KC/pages/11337790/CxSAST+Jenkins+Plugin)

--- a/build.gradle
+++ b/build.gradle
@@ -110,7 +110,7 @@ jenkinsPlugin {
     displayName = 'Jenkins Checkmarx Plugin'
 
     // URL for plugin on Jenkins wiki or elsewhere
-    url = 'https://wiki.jenkins-ci.org/display/JENKINS/Checkmarx+CxSAST+Plugin'
+    url = 'https://github.com/jenkinsci/checkmarx-plugin'
 
     // plugin URL on GitHub, optional
     gitHubUrl = 'https://github.com/jenkinsci/checkmarx-plugin.git'


### PR DESCRIPTION
## Move documentation into the GitHub repository

Copied from https://github.com/jenkins-infra/plugins-wiki-docs/tree/master/checkmarx archive of plugin wiki content as markdown files.

See the [Plugin documentatin as code blog post](https://www.jenkins.io/blog/2019/10/21/plugin-docs-on-github/) and the ["Using GitHub as a source of documentation"](https://www.jenkins.io/doc/developer/publishing/documentation/#documenting-plugins) as good references.  The ["participate in documentation"](https://www.jenkins.io/participate/document/) page includes a [video](https://youtu.be/BaEJ8v7INNQ) that illustrates how to make that change as well.
