### PR TITLE
Fix a NullPointerException when no groupId is provided

### DIFF
--- a/src/main/java/com/checkmarx/jenkins/CxScanBuilder.java
+++ b/src/main/java/com/checkmarx/jenkins/CxScanBuilder.java
@@ -1318,7 +1318,9 @@ public class CxScanBuilder extends Builder implements SimpleBuildStep {
         } else {
             ret.setProxy(false);
         }
-        teamPath = getTeamNameFromId(cxConnectionDetails, descriptor, groupId);
+        if (teamPath == null) {
+            teamPath = getTeamNameFromId(cxConnectionDetails, descriptor, groupId);
+        }
         //project
         ret.setProjectName(env.expand(projectName.trim()));
         ret.setTeamPath(teamPath);


### PR DESCRIPTION
The [documentation](https://checkmarx.atlassian.net/wiki/spaces/SD/pages/1457226433/Setting+up+Scans+in+Jenkins) explicitly says that the `teamPath` parameter
overrides the `groupId` and it even recommends removing the `groupId`
parameter if the `teamPath` is set.
This fix prevents the CxCommonClient from throwing a NullPointerException
when the `groupId` is null if the `teamPath` parameter has some value.

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
