### PR TITLE
Fix NPE when the "isProxy" method returns null

### DIFF
--- a/src/main/java/com/checkmarx/jenkins/CxScanBuilder.java
+++ b/src/main/java/com/checkmarx/jenkins/CxScanBuilder.java
@@ -1305,7 +1305,7 @@ public class CxScanBuilder extends Builder implements SimpleBuildStep {
         ret.setUrl(cxConnectionDetails.getServerUrl().trim());
         ret.setUsername(cxConnectionDetails.getUsername());
         ret.setPassword(Aes.decrypt(cxConnectionDetails.getPassword(), cxConnectionDetails.getUsername()));
-        if (cxConnectionDetails.isProxy()) {
+        if (cxConnectionDetails.isProxy() != null && cxConnectionDetails.isProxy()) {
             Jenkins instance = Jenkins.getInstance();
             if (instance != null && instance.proxy != null && !(isCxURLinNoProxyHost(useOwnServerCredentials ?
                     this.serverUrl : getDescriptor().getServerUrl(), instance.proxy.getNoProxyHostPatterns()))) {


### PR DESCRIPTION
Fix the NullPointerException since `cxConnectionDetails.isProxy()` has null value and we see the following:
```
12:14:54 ERROR: Build step failed with exception
12:14:54 java.lang.NullPointerException
12:14:54 	at com.checkmarx.jenkins.CxScanBuilder.resolveConfiguration(CxScanBuilder.java:1300)
12:14:54 	at com.checkmarx.jenkins.CxScanBuilder.perform(CxScanBuilder.java:870)
12:14:54 	at jenkins.tasks.SimpleBuildStep.perform(SimpleBuildStep.java:123)
12:14:54 	at hudson.tasks.BuildStepCompatibilityLayer.perform(BuildStepCompatibilityLayer.java:80)
12:14:54 	at hudson.tasks.BuildStepMonitor$1.perform(BuildStepMonitor.java:20)
12:14:54 	at hudson.model.AbstractBuild$AbstractBuildExecution.perform(AbstractBuild.java:803)
12:14:54 	at hudson.model.Build$BuildExecution.build(Build.java:197)
12:14:54 	at hudson.model.Build$BuildExecution.doRun(Build.java:163)
12:14:54 	at hudson.model.AbstractBuild$AbstractBuildExecution.run(AbstractBuild.java:513)
12:14:54 	at hudson.model.Run.execute(Run.java:1906)
12:14:54 	at hudson.model.FreeStyleBuild.run(FreeStyleBuild.java:43)
12:14:54 	at hudson.model.ResourceController.execute(ResourceController.java:97)
12:14:54 	at hudson.model.Executor.run(Executor.java:429)
12:14:54 Build step 'Execute Checkmarx Scan' marked build as failure
```

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
