### PR TITLE
Groupid teampath support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,9 +60,9 @@ dependencies {
             'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.11.3',
             'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.10.5',
             'com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.10.5',
-            'org.apache.logging.log4j:log4j-slf4j-impl:2.17.0',
-            'org.apache.logging.log4j:log4j-api:2.17.0',
-            'org.apache.logging.log4j:log4j-core:2.17.0'
+            'org.apache.logging.log4j:log4j-slf4j-impl:2.17.1',
+            'org.apache.logging.log4j:log4j-api:2.17.1',
+            'org.apache.logging.log4j:log4j-core:2.17.1'
             constraints {
                 implementation('io.vertx:vertx-web:3.9.7') {
                     because 'previous versions have a bug impacting this application'


### PR DESCRIPTION
- Added SCA Resolver support
- Fixed issue in pipeline job so that groupId or teamPath , any of these can be provided.
- The below third party libraries have been upgraded
o Library “org.apache.logging.log4j:log4j-core” to 2.17.1.
o Library “org.apache.logging.log4j:log4j-api” to 2.17.1
o Library “org.apache.logging.log4j:log4j-slf4j-impl” to 2.17.1.