### PR TITLE
Fix for serialization issue in agent-server mode

### DIFF
--- a/src/main/java/com/checkmarx/jenkins/CxScanResult.java
+++ b/src/main/java/com/checkmarx/jenkins/CxScanResult.java
@@ -47,7 +47,6 @@ public class CxScanResult implements Action {
     private long scanId;
 
     private Boolean sastEnabled;
-    private Boolean astSastEnabled;
     private boolean osaEnabled;
 
     //Resultsalc
@@ -75,10 +74,9 @@ public class CxScanResult implements Action {
         this.htmlReportName = htmlReportName;
     }
 
-    public CxScanResult(Run<?, ?> owner, CxScanConfig config, boolean astSastEnabled) {
+    public CxScanResult(Run<?, ?> owner, CxScanConfig config) {
         this.scanRanAsynchronous = !config.getSynchronous();
         this.sastEnabled = config.isSastEnabled();
-        this.astSastEnabled = astSastEnabled;
         this.osaEnabled = config.isOsaEnabled();
         this.owner = owner;
         this.resultDeepLink = "";

--- a/src/main/java/com/checkmarx/jenkins/RemoteScanInfo.java
+++ b/src/main/java/com/checkmarx/jenkins/RemoteScanInfo.java
@@ -11,8 +11,17 @@ import java.io.Serializable;
 public class RemoteScanInfo implements Serializable {
     private ScanResults scanResults;
     private String cxARMUrl;
+    private boolean cxOneSASTEnabled;
 
-    public void setScanResults(ScanResults scanResults) {
+	public boolean isCxOneSASTEnabled() {
+		return cxOneSASTEnabled;
+	}
+
+	public void setCxOneSASTEnabled(boolean cxOneSASTEnabled) {
+		this.cxOneSASTEnabled = cxOneSASTEnabled;
+	}
+
+	public void setScanResults(ScanResults scanResults) {
         this.scanResults = scanResults;
     }
 

--- a/src/main/resources/META-INF/hudson.remoting.ClassFilter
+++ b/src/main/resources/META-INF/hudson.remoting.ClassFilter
@@ -19,6 +19,7 @@ com.cx.restclient.ast.dto.sast.AstSASTParam
 com.cx.restclient.ast.dto.sast.AstSastQueryCounter
 com.cx.restclient.ast.dto.sast.AstSastResults
 com.checkmarx.one.dto.migration.MigratedGroup
+com.checkmarx.one.dto.migration.MigratedPreset
 com.checkmarx.one.dto.scan.sast.SastResultDetails
 com.checkmarx.one.dto.scan.sast.SastResultNodeResponse
 com.checkmarx.one.dto.scan.sast.SastResults


### PR DESCRIPTION
SHA-1: 6a197a5f19c366b250c9f70a8df3601de811e6ec commit ID in cx-client-common

* Fixed issues around report generation in agent-master mode
Modified SummaryUtils to add sast/OSA/SCA/CxOneSast to template data of report ftl only if that scan result is available
