### PR TITLE
SSL/TLS validation is disabled by default

### DIFF
--- a/src/main/java/com/checkmarx/jenkins/CxScanBuilder.java
+++ b/src/main/java/com/checkmarx/jenkins/CxScanBuilder.java
@@ -2170,7 +2170,7 @@ public class CxScanBuilder extends Builder implements SimpleBuildStep {
         private boolean hideResults;
         private boolean asyncHtmlRemoval;
 
-        private boolean enableCertificateValidation;
+        private boolean enableCertificateValidation = true;
         @Nullable
         private String excludeFolders;
         @Nullable
@@ -2513,7 +2513,7 @@ public class CxScanBuilder extends Builder implements SimpleBuildStep {
          *  shared state to avoid synchronization issues.
          */
         @POST
-        public FormValidation doTestConnection(@QueryParameter final String serverUrl, @QueryParameter final String password,
+        public FormValidation doTestConnection(@QueryParameter final boolean enableCertificateValidation,@QueryParameter final String serverUrl, @QueryParameter final String password,
                                                @QueryParameter final String username, @QueryParameter final String timestamp,
                                                @QueryParameter final String credentialsId, @QueryParameter final boolean isProxy, @AncestorInPath Item item) {
             if(item==null){

--- a/src/main/resources/com/checkmarx/jenkins/CxScanBuilder/global.jelly
+++ b/src/main/resources/com/checkmarx/jenkins/CxScanBuilder/global.jelly
@@ -42,7 +42,7 @@
         <f:optionalBlock title="Use Jenkins proxy" inline="true" field="isProxy" />
 
 		<f:validateButton title="Test Connection" progress="Testing..." method="testConnection"
-			with="isProxy,serverUrl,username,password,timestamp,credentialsId" />
+			with="enableCertificateValidation,isProxy,serverUrl,username,password,timestamp,credentialsId" />
 
         <f:entry title="Maven Path" field="mvnPath">
             <f:textbox/>


### PR DESCRIPTION
1. checkbox checked by default when we start fresh jenkins home

2. without certificate imported(with both cases: checkbox checked and unchecked)

    error message: PKIX path building failed: sun.security.provider.certpath.SunCertPathBuilderException: unable to find valid certification path to requested target

  3. with certificate imported(with both cases: checkbox checked and unchecked)

    message: Success