### PR TITLE
Plug 49 sca reports

### DIFF
--- a/src/main/java/com/checkmarx/jenkins/CxScanBuilder.java
+++ b/src/main/java/com/checkmarx/jenkins/CxScanBuilder.java
@@ -169,6 +169,7 @@ public class CxScanBuilder extends Builder implements SimpleBuildStep {
     private boolean failBuildOnNewResults;
     private String failBuildOnNewSeverity;
     private boolean generatePdfReport;
+    private boolean generateScaReport;
     private boolean enableProjectPolicyEnforcement;
     @Nullable
     private Integer osaHighThreshold;
@@ -208,6 +209,7 @@ public class CxScanBuilder extends Builder implements SimpleBuildStep {
     CxLoggerAdapter log;
 
     private JobStatusOnError jobStatusOnError;
+    private ScaReportFormat scaReportFormat;
     private String exclusionsSetting;
     private String thresholdSettings;
     private Result vulnerabilityThresholdResult;
@@ -238,6 +240,7 @@ public class CxScanBuilder extends Builder implements SimpleBuildStep {
             Boolean sastEnabled,
             @Nullable String preset,
             JobStatusOnError jobStatusOnError,
+            ScaReportFormat scaReportFormat,
             boolean presetSpecified,
             String exclusionsSetting,
             @Nullable String excludeFolders,
@@ -260,6 +263,7 @@ public class CxScanBuilder extends Builder implements SimpleBuildStep {
             @Nullable Integer osaMediumThreshold,
             @Nullable Integer osaLowThreshold,
             boolean generatePdfReport,
+            boolean generateScaReport,
             boolean enableProjectPolicyEnforcement,
             String thresholdSettings,
             String vulnerabilityThresholdResult,
@@ -287,6 +291,7 @@ public class CxScanBuilder extends Builder implements SimpleBuildStep {
         this.sastEnabled = sastEnabled;
         this.preset = (preset != null && !preset.startsWith("Provide Checkmarx")) ? preset : null;
         this.jobStatusOnError = jobStatusOnError;
+        this.scaReportFormat = scaReportFormat;
         this.presetSpecified = presetSpecified;
         this.exclusionsSetting = exclusionsSetting;
         this.globalExclusions = "global".equals(exclusionsSetting);
@@ -310,6 +315,7 @@ public class CxScanBuilder extends Builder implements SimpleBuildStep {
         this.osaMediumThreshold = osaMediumThreshold;
         this.osaLowThreshold = osaLowThreshold;
         this.generatePdfReport = generatePdfReport;
+        this.generateScaReport = generateScaReport;
         this.enableProjectPolicyEnforcement = enableProjectPolicyEnforcement;
         this.thresholdSettings = thresholdSettings;
         if (vulnerabilityThresholdResult != null) {
@@ -611,6 +617,10 @@ public class CxScanBuilder extends Builder implements SimpleBuildStep {
     public boolean isGeneratePdfReport() {
         return generatePdfReport;
     }
+    
+    public boolean isGenerateScaReport() {
+		return generateScaReport;
+	}
 
     public boolean isEnableProjectPolicyEnforcement() {
         return enableProjectPolicyEnforcement;
@@ -768,6 +778,11 @@ public class CxScanBuilder extends Builder implements SimpleBuildStep {
     public void setGeneratePdfReport(boolean generatePdfReport) {
         this.generatePdfReport = generatePdfReport;
     }
+    
+    @DataBoundSetter
+    public void setGenerateScaReport(boolean generateScaReport) {
+		this.generateScaReport = generateScaReport;
+	}
 
     @DataBoundSetter
     public void setEnableProjectPolicyEnforcement(boolean enableProjectPolicyEnforcement) {
@@ -940,9 +955,11 @@ public class CxScanBuilder extends Builder implements SimpleBuildStep {
         final DescriptorImpl descriptor = getDescriptor();
         EnvVars env = run.getEnvironment(listener);
         setJvmVars(env);
-        Map<String, String> fsaVars = getAllFsaVars(env, workspace.getRemote());
-        CxScanConfig config = resolveConfiguration(run, descriptor, env, log, workspace);
-
+        Map<String, String> fsaVars = getAllFsaVars(env);
+        CxScanConfig config;
+		try {
+			config = resolveConfiguration(run, descriptor, env, log,  workspace);
+        
         if (configAsCode) {
             try {
                 overrideConfigAsCode(config, workspace);
@@ -1004,6 +1021,28 @@ public class CxScanBuilder extends Builder implements SimpleBuildStep {
                 scanResults.getSastResults().setSastPDFLink(pdfUrl);
             }
         }
+        
+        if (config.isGenerateScaReport()) {
+        	if(config.getScaReportFormat() != null) {
+            String path = "";
+            // run.getUrl() returns a URL path similar to job/MyJobName/124/
+            //getRootUrl() will return the value of "Manage Jenkins->configuration->Jenkins URL"
+            String baseUrl = Jenkins.getInstance().getRootUrl();
+            if (StringUtils.isNotEmpty(baseUrl)) {
+                URL parsedUrl = new URL(baseUrl);
+                path = parsedUrl.getPath();
+            }
+            if (!(path.equals("/"))) {
+                //to handle this Jenkins root url,EX: http://localhost:8081/jenkins
+                Path pdfUrlPath = Paths.get(path, run.getUrl(), PDF_URL);
+                scanResults.getScaResults().setScaPDFLink(pdfUrlPath.toString());
+            } else {
+                //to handle this Jenkins root url,EX: http://localhost:8081/
+                String pdfUrl = String.format(PDF_URL_TEMPLATE, run.getUrl());
+                scanResults.getScaResults().setScaPDFLink(pdfUrl);
+            }
+        	}
+        }
 
         //in case of async mode, do not create reports (only the report of the latest scan)
         //and don't assert threshold vulnerabilities
@@ -1015,6 +1054,7 @@ public class CxScanBuilder extends Builder implements SimpleBuildStep {
             String reportName = generateHTMLReport(workspace, checkmarxBuildDir, config, scanResults);
             cxScanResult.setHtmlReportName(reportName);
             run.addAction(cxScanResult);
+            
 
 
             //create sast reports
@@ -1044,6 +1084,9 @@ public class CxScanBuilder extends Builder implements SimpleBuildStep {
             cxScanResult.setHtmlReportName(reportName);
         }
         run.addAction(cxScanResult);
+			} catch (ConfigurationException e1) {
+				e1.printStackTrace();
+			}
     }
 
     private void overrideConfigAsCode(CxScanConfig config, FilePath workspace) throws ConfigurationException {
@@ -1274,6 +1317,14 @@ public class CxScanBuilder extends Builder implements SimpleBuildStep {
         writeJsonObjectToFile(scaResults.getSummary(), checkmarxBuildDir, SCA_SUMMERY_JSON);
         writeJsonObjectToFile(scaResults.getPackages(), checkmarxBuildDir, SCA_LIBRARIES_JSON);
         writeJsonObjectToFile(scaResults.getFindings(), checkmarxBuildDir, SCA_VULNERABILITIES_JSON);
+        if (scaResults.getPDFReport() != null) {
+            File pdfReportFile = new File(checkmarxBuildDir, CxScanResult.PDF_REPORT_NAME);
+            try {
+                FileUtils.writeByteArrayToFile(pdfReportFile, scaResults.getPDFReport());
+            } catch (IOException e) {
+                log.warn("Failed to write SCA PDF report to workspace: " + e.getMessage());
+            }
+        }
     }
 
     /**
@@ -1359,7 +1410,7 @@ public class CxScanBuilder extends Builder implements SimpleBuildStep {
         }
         return true;
     }
-    private CxScanConfig resolveConfiguration(Run<?, ?> run, DescriptorImpl descriptor, EnvVars env, CxLoggerAdapter log, FilePath workspace) throws IOException {
+    private CxScanConfig resolveConfiguration(Run<?, ?> run, DescriptorImpl descriptor, EnvVars env, CxLoggerAdapter log, FilePath workspace) throws IOException, ConfigurationException {
         CxScanConfig ret = new CxScanConfig();
         
         ret.setIsOverrideProjectSetting(overrideProjectSetting);
@@ -1534,6 +1585,20 @@ public class CxScanBuilder extends Builder implements SimpleBuildStep {
             enableProjectPolicyEnforcement = false;
         }
         ret.setEnablePolicyViolations(enableProjectPolicyEnforcement);
+        
+        if (!ret.isAstScaEnabled() || !ret.getSynchronous()) {
+        	generateScaReport = false;
+        }
+		if (ret.isAstScaEnabled()) {
+			ret.setGenerateScaReport(generateScaReport);
+			ret.setScaReportFormat(scaReportFormat.name());
+			if (ret.getScaReportFormat() != null && !ret.getScaReportFormat().isEmpty()) {
+				ret.setGenerateScaReport(true);
+			} else {
+				ret.setGenerateScaReport(false);
+				throw new ConfigurationException("Invalid SCA report format:" + scaReportFormat + ".");
+			}
+		}
         
         // Set the Continue build flag to Configuration object if Option from UI is choosen as useContinueBuildOnError
         if (useContinueBuildOnError(getDescriptor())) {
@@ -1832,6 +1897,7 @@ public class CxScanBuilder extends Builder implements SimpleBuildStep {
                 log.info("CxSCA web app URL: " + config.getAstScaConfig().getWebAppUrl());
                 log.info("Account: " + config.getAstScaConfig().getTenant());
                 log.info("Team: " + config.getAstScaConfig().getTeamPath());
+                log.info("is generate SCA report: "+ config.isGenerateScaReport());
             }
         }
 
@@ -2243,6 +2309,15 @@ public class CxScanBuilder extends Builder implements SimpleBuildStep {
         return (DescriptorImpl) super.getDescriptor();
     }
 
+    public ScaReportFormat getScaReportFormat() {
+		return scaReportFormat;
+	}
+
+	@DataBoundSetter
+	public void setScaReportFormat(ScaReportFormat scaReportFormat) {
+		this.scaReportFormat = scaReportFormat;
+	}
+    
     @Extension
     public static final class DescriptorImpl extends BuildStepDescriptor<Builder> {
 
@@ -2760,6 +2835,22 @@ public class CxScanBuilder extends Builder implements SimpleBuildStep {
 
             return FormValidation.ok();
         }
+        
+        @POST
+        public FormValidation doCheckGenerateScaReport(@QueryParameter boolean value, @QueryParameter boolean dependencyScanConfig, @QueryParameter boolean generateScaReport,@AncestorInPath Item item) {
+        	if (item == null) {
+                return FormValidation.ok();
+        	}
+            item.checkPermission(Item.CONFIGURE);
+            if (!dependencyScanConfig && value) {
+            	generateScaReport=false;
+            	dependencyScanConfig = false;
+            	return FormValidation.error("Enable dependency scanner as SCA");
+            }
+
+            return FormValidation.ok();
+        }
+        
 
         @POST
         public FormValidation doTestScaSASTConnection(@QueryParameter final String scaSastServerUrl, @QueryParameter final String password,
@@ -3186,6 +3277,19 @@ public class CxScanBuilder extends Builder implements SimpleBuildStep {
 
             return listBoxModel;
         }
+        
+        @POST
+		public ListBoxModel doFillScaReportFormat(@AncestorInPath Item item) {
+			if (item == null) {
+				return new ListBoxModel();
+			}
+			item.checkPermission(Item.CONFIGURE);
+			ListBoxModel listBoxModel = new ListBoxModel();
+			for (ScaReportFormat status : ScaReportFormat.values()) {
+				listBoxModel.add(new ListBoxModel.Option(status.getDisplayName(), status.name()));
+			}
+			return listBoxModel;
+		}
 
 
         /*

--- a/src/main/java/com/checkmarx/jenkins/CxScanBuilder.java
+++ b/src/main/java/com/checkmarx/jenkins/CxScanBuilder.java
@@ -955,7 +955,7 @@ public class CxScanBuilder extends Builder implements SimpleBuildStep {
         final DescriptorImpl descriptor = getDescriptor();
         EnvVars env = run.getEnvironment(listener);
         setJvmVars(env);
-        Map<String, String> fsaVars = getAllFsaVars(env);
+        Map<String, String> fsaVars = getAllFsaVars(env, workspace.getRemote());
         CxScanConfig config;
 		try {
 			config = resolveConfiguration(run, descriptor, env, log,  workspace);
@@ -1317,14 +1317,6 @@ public class CxScanBuilder extends Builder implements SimpleBuildStep {
         writeJsonObjectToFile(scaResults.getSummary(), checkmarxBuildDir, SCA_SUMMERY_JSON);
         writeJsonObjectToFile(scaResults.getPackages(), checkmarxBuildDir, SCA_LIBRARIES_JSON);
         writeJsonObjectToFile(scaResults.getFindings(), checkmarxBuildDir, SCA_VULNERABILITIES_JSON);
-        if (scaResults.getPDFReport() != null) {
-            File pdfReportFile = new File(checkmarxBuildDir, CxScanResult.PDF_REPORT_NAME);
-            try {
-                FileUtils.writeByteArrayToFile(pdfReportFile, scaResults.getPDFReport());
-            } catch (IOException e) {
-                log.warn("Failed to write SCA PDF report to workspace: " + e.getMessage());
-            }
-        }
     }
 
     /**

--- a/src/main/java/com/checkmarx/jenkins/DependencyScanConfig.java
+++ b/src/main/java/com/checkmarx/jenkins/DependencyScanConfig.java
@@ -78,6 +78,9 @@ public class DependencyScanConfig {
     public Integer scaTimeout;
     
     @DataBoundSetter
+    public boolean generateScaReport;
+    
+    @DataBoundSetter
     public boolean isIncludeSources;
 
     @DataBoundSetter

--- a/src/main/java/com/checkmarx/jenkins/ScaReportFormat.java
+++ b/src/main/java/com/checkmarx/jenkins/ScaReportFormat.java
@@ -1,0 +1,15 @@
+package com.checkmarx.jenkins;
+
+public enum ScaReportFormat {
+	PDF("PDF"), XML("XML"), CSV("CSV"), JSON("JSON"), cyclonedxjson("cyclonedxjson"), cyclonedxxml("cyclonedxxml");
+
+	private final String displayName;
+
+	ScaReportFormat(String displayName) {
+		this.displayName = displayName;
+	}
+
+	public String getDisplayName() {
+		return displayName;
+	}
+}

--- a/src/main/resources/com/checkmarx/jenkins/CxScanBuilder/config.jelly
+++ b/src/main/resources/com/checkmarx/jenkins/CxScanBuilder/config.jelly
@@ -323,6 +323,15 @@
                     <!-- -= Generate PDF report =- -->
                     <f:optionalBlock title="Generate CxSAST PDF report" inline="true" field="generatePdfReport" />
 
+					<!-- -= generateScaReport =- -->
+                	<f:optionalBlock title="Generate SCA report" inline="true" field="generateScaReport" checkMethod="POST"
+                	checked="${instance.dependencyScanConfig.dependencyScannerType == 'SCA'}">
+
+                		<f:entry name="scaReportFormat" title="Report Format:" field="scaReportFormat">
+            			<f:enum field="scaReportFormat">${it.displayName}</f:enum>
+            			</f:entry>
+           			</f:optionalBlock>
+
                     <!-- -= enableProjectPolicyEnforcement =- -->
                     <f:optionalBlock title="Enable Project's policy enforcement" inline="true" field="enableProjectPolicyEnforcement" />
 

--- a/src/main/resources/com/checkmarx/jenkins/CxScanBuilder/help-generateScaReport.html
+++ b/src/main/resources/com/checkmarx/jenkins/CxScanBuilder/help-generateScaReport.html
@@ -1,0 +1,3 @@
+<div>
+    Downloads a PDF report with scan results from the Checkmarx server. The report is available via a link on "Checkmarx Scan Results" page.
+</div>


### PR DESCRIPTION
Test cases I had covered while testing regarding report generation for sca for plug 49 i.e. Report with results of both SCA and SAST from Jenkins Plugin:

checkbox of generate Sca report is present in Enable synchronous mode.

If user unselects Enable dependency scan, dynamically it should give error message with "Enable dependency scanner as SCA" downside of checkbox. After user selects apply and save go back to configure Generate SCA report checkbox should be unchecked.

If user unselects Enable synchronous mode, After user selects apply and save go back to configure Generate SCA report checkbox should be unchecked.

If User selects sca report type as pdf it should get downloaded locally at C:\Users\swatia\jenkins_home30\.jenkins\workspace\aaa\Checkmarx\Reports and in build directory C:\Users\swatia\jenkins_home30\.jenkins\jobs\aaa\builds\102\checkmarx.

If User selects sca report type as pdf in checkmarx report section should be able to see pdf report icon and when clicked report should get opened.

Able to download all reports of type pdf,json,csv,xml,cyclonedxjson,cyclonedxxml
----------------------------------------

There is seperate section for generating SCA Report. Report format will be selectable by user.
Generate report of pdf type will be effective only if it is Synchronous scan