### PR TITLE
Support for project level custom field

### DIFF
--- a/src/main/java/com/checkmarx/jenkins/CxScanBuilder.java
+++ b/src/main/java/com/checkmarx/jenkins/CxScanBuilder.java
@@ -1349,7 +1349,6 @@ public class CxScanBuilder extends Builder implements SimpleBuildStep {
 		if (config.isGenerateScaReport()) {
 			if (scaResults.getPDFReport() != null && "pdf".equalsIgnoreCase(config.getScaReportFormat())) {
 				File pdfReportFile = new File(checkmarxBuildDir, CxScanResult.SCA_PDF_REPORT_NAME);
-				log.info("PDF Report generated at location: " + pdfReportFile.getAbsolutePath());
 				try {
 					FileUtils.writeByteArrayToFile(pdfReportFile, scaResults.getPDFReport());
 					scaResults.setScaPDFLink(checkmarxBuildDir + File.separator + CxScanResult.SCA_PDF_REPORT_NAME);

--- a/src/main/java/com/checkmarx/jenkins/CxScanBuilder.java
+++ b/src/main/java/com/checkmarx/jenkins/CxScanBuilder.java
@@ -1437,7 +1437,7 @@ public class CxScanBuilder extends Builder implements SimpleBuildStep {
     }
 
     private Boolean verifyCustomCharacters(String inputString) {
-        Pattern pattern = Pattern.compile("(^([a-zA-Z0-9#._]*):([a-zA-Z0-9#._]*)+(,([a-zA-Z0-9#._]*):([a-zA-Z0-9#._]*)+)*$)");
+        Pattern pattern = Pattern.compile("^([a-zA-Z0-9#._!%@;$&\\/\\*\\^\\-\\s\\w]*):([a-zA-Z0-9#._!%@;$&\\/\\*\\^\\-\\s\\w]*)+(,([a-zA-Z0-9#._!%@;$&\\/\\*\\^\\-\\s\\w]*):([a-zA-Z0-9#._!%@;$&\\/\\*\\^\\-\\s\\w]*)+)*$");
         Matcher match = pattern.matcher(inputString);
         if (!StringUtil.isNullOrEmpty(inputString) && !match.find()) {
             return false;
@@ -1483,7 +1483,7 @@ public class CxScanBuilder extends Builder implements SimpleBuildStep {
         
         if(StringUtils.isNotEmpty(getProjectLevelCustomFields())) {
 	        if(!verifyCustomCharacters(getProjectLevelCustomFields())) {
-	        	throw new CxClientException("Custom Fields must have given format: field1:value1,field2:value2. \\nCustom field allows to use these special characters: # . _ ");
+	        	throw new CxClientException("Custom Fields must have given format: key1:val1,key2:val2. \\nCustom field allows to use these special characters : # . _ ! % @ ; $ & / * ^ - and space");
 	        }
 	        ret.setProjectLevelCustomFields(getProjectLevelCustomFields());
         }
@@ -3041,7 +3041,7 @@ public class CxScanBuilder extends Builder implements SimpleBuildStep {
             Pattern pattern = Pattern.compile("^([a-zA-Z0-9#._!%@;$&\\/\\*\\^\\-\\s\\w]*):([a-zA-Z0-9#._!%@;$&\\/\\*\\^\\-\\s\\w]*)+(,([a-zA-Z0-9#._!%@;$&\\/\\*\\^\\-\\s\\w]*):([a-zA-Z0-9#._!%@;$&\\/\\*\\^\\-\\s\\w]*)+)*$");
             Matcher match = pattern.matcher(value);
             if (!StringUtil.isNullOrEmpty(value) && !match.find()) {
-            	return FormValidation.error("Custom Fields must have given format: key1:val1,key2:val2. \nCustom field allows to use these special characters: # . _ ");
+            	return FormValidation.error("Custom Fields must have given format: key1:val1,key2:val2. \\nCustom field allows to use these special characters : # . _ ! % @ ; $ & / * ^ - and space");
             }
 
             return FormValidation.ok();
@@ -3059,10 +3059,10 @@ public class CxScanBuilder extends Builder implements SimpleBuildStep {
                 return FormValidation.ok();
         	}
             item.checkPermission(Item.CONFIGURE);
-            Pattern pattern = Pattern.compile("(^([a-zA-Z0-9#._]*):([a-zA-Z0-9#._]*)+(,([a-zA-Z0-9#._]*):([a-zA-Z0-9#._]*)+)*$)");
+            Pattern pattern = Pattern.compile("^([a-zA-Z0-9#._!%@;$&\\/\\*\\^\\-\\s\\w]*):([a-zA-Z0-9#._!%@;$&\\/\\*\\^\\-\\s\\w]*)+(,([a-zA-Z0-9#._!%@;$&\\/\\*\\^\\-\\s\\w]*):([a-zA-Z0-9#._!%@;$&\\/\\*\\^\\-\\s\\w]*)+)*$");
             Matcher match = pattern.matcher(value);
             if (!StringUtil.isNullOrEmpty(value) && !match.find()) {
-            	return FormValidation.error("Custom Fields must have given format: key1:val1,key2:val2. \nCustom field allows to use these special characters: # . _ ");
+            	return FormValidation.error("Custom Fields must have given format: key1:val1,key2:val2. \\nCustom field allows to use these special characters : # . _ ! % @ ; $ & / * ^ - and space");
             }
 
             return FormValidation.ok();

--- a/src/main/java/com/checkmarx/jenkins/CxScanBuilder.java
+++ b/src/main/java/com/checkmarx/jenkins/CxScanBuilder.java
@@ -2038,6 +2038,7 @@ public class CxScanBuilder extends Builder implements SimpleBuildStep {
             log.info("Copying file {} to workspace {}", fileName, remoteFilePath);
             FilePath remoteFile = new FilePath(to.getChannel(), remoteFilePath);
             remoteFile.copyFrom(is);
+            log.info("File {} successfully written to workspace", fileName);
         } catch (Exception e) {
             log.error("Failed to write '" + fileName + "' to [" + to.getRemote() + "]", e);
         } finally {

--- a/src/main/resources/com/checkmarx/jenkins/CxScanBuilder/config.jelly
+++ b/src/main/resources/com/checkmarx/jenkins/CxScanBuilder/config.jelly
@@ -117,6 +117,12 @@
             <f:checkbox checkMethod="POST" checked="${instance.forceScan}"/>
         </f:entry>
 
+
+        <f:entry title="Project level - custom fields" field="projectLevelCustomFields">
+        	<f:textbox checkMethod="POST" value="${instance.projectLevelCustomFields}" />
+        </f:entry>
+
+
 		<f:entry title="Scan level - custom fields" field="customFields">
         	<f:textbox checkMethod="POST" value="${instance.customFields}" />
         </f:entry>

--- a/src/main/resources/com/checkmarx/jenkins/CxScanBuilder/help-projectLevelCustomFields.html
+++ b/src/main/resources/com/checkmarx/jenkins/CxScanBuilder/help-projectLevelCustomFields.html
@@ -1,0 +1,3 @@
+<div>
+	Add scan level custom fields and its value. Example: field1:value1,field2:value2.(Note that the feature works with 9.4 version SAST onwards.)
+</div>


### PR DESCRIPTION
Test Case 1
Go to SAST portal -> Setting Manage custom field -> Add Custom fields
custom1
custom2
custom3
Create project using SAST portal and with below custom fields(wait to finish scan)
custom1 = ABC
custom2 = DEF
Verify custom fields values in projects tab (Values added for custom1 and custom2 will display)
Test Case 2
Run SAST scan with jenkins plugin -> project level custom field is blanck(wait till pipeline successfull)
Go to SAST portal and verify custom field value for same project (it remains same value that previously added)
custom1 = ABC
custom2 = DEF
custom3 = ''
Test Case 3
Run SAST scan with jenkins plugin -> project level custom field = custom3 = XYZ(wait till pipeline successfull)
Go to SAST portal and verify custom field value for same project
Expected output - custom1 = ABC, custom2 = DEF and custom3 = XYZ
Test Case 4
Run SAST scan with jenkins plugin -> project level custom field = custom2 = MNO(wait till pipeline successfull)
Go to SAST portal and verify custom field value for same project
Expected output - custom1 = ABC, custom2 = MNO and custom3 = XYZ