### PR TITLE
 2024_Q2: Updated condition (Optimized) for PLUG-806 

### DIFF
--- a/src/main/java/com/checkmarx/jenkins/CxScanBuilder.java
+++ b/src/main/java/com/checkmarx/jenkins/CxScanBuilder.java
@@ -1117,8 +1117,8 @@ public class CxScanBuilder extends Builder implements SimpleBuildStep {
             return;
         }
 
-		// For asynchronous scan, if reports are not ready or previous reports is not
-		// found, HTML Report is not generated
+		/* For asynchronous scan, if reports are not ready or report of previous successful scan is not
+		 found, HTML Report is not generated*/
 		boolean generateAsyncReport = false;
 		SASTResults sastResults = scanResults.getSastResults();
 		OSAResults osaResults = scanResults.getOsaResults();
@@ -1126,38 +1126,17 @@ public class CxScanBuilder extends Builder implements SimpleBuildStep {
 		if (config.isSastEnabled() && sastResults != null && sastResults.isSastResultsReady()) {
 			generateAsyncReport = true;
 		}
-
+		
+		/*If a combination scan is run(SAST + OSA/SCA), 
+		HTML report is generated only if, previous reports are available for both the scans*/
 		if (config.isOsaEnabled() || config.isAstScaEnabled()) {
-			if (config.isOsaEnabled()) {
-				if (osaResults == null || !osaResults.isOsaResultsReady()) {
-					generateAsyncReport = false;
-				} else {
-					/*If both SAST and OSA scan are enabled, 
-					HTML report is generated only if,previous report is available for both the scan*/
-					
-					if(config.isSastEnabled()){ 
-						if(sastResults == null || !sastResults.isSastResultsReady()) {
-							generateAsyncReport = false;
-						}
-					}else {
-					generateAsyncReport = true;
-					}
-				}
+			if ((config.isOsaEnabled() && (osaResults == null || !osaResults.isOsaResultsReady()))
+					|| (config.isAstScaEnabled() && (scaResults == null || !scaResults.isScaResultReady()))
+					|| (config.isSastEnabled() && (sastResults == null || !sastResults.isSastResultsReady()))) {
+				generateAsyncReport = false;
 			} else {
-				if (scaResults == null || !scaResults.isScaResultReady()) {
-					generateAsyncReport = false;
-				} else {
-					/*If both SAST and SCA scan are enabled, 
-					HTML report is generated only if,previous report is available for both the scan*/
-					if(config.isSastEnabled()){
-						if(sastResults == null || !sastResults.isSastResultsReady()) {
-							generateAsyncReport = false;
-						}
-					}else {
-					generateAsyncReport = true;
-					}
-				}
-			} 
+				generateAsyncReport = true;
+			}
 		}
 
 		if (!descriptor.isAsyncHtmlRemoval() || config.getSynchronous()) {

--- a/src/main/java/com/checkmarx/jenkins/CxScanResult.java
+++ b/src/main/java/com/checkmarx/jenkins/CxScanResult.java
@@ -176,7 +176,6 @@ public class CxScanResult implements Action {
  // Check if neither the current report nor the older report is found	
 	public boolean isEmptyReportAsync() {
 		try {
-			boolean isRemoveAsyncHtmlValue = isRemoveAsyncHtml();
 			String htmlReport = getHtmlReport();
 			return htmlReport == null || htmlReport.isEmpty()
 					|| htmlReport.equals("<h1>Checkmarx HTML report not found<h1>");


### PR DESCRIPTION
This PR addresses the following:

**[(Link to previous pull request regarding same issue)](https://github.com/jenkinsci/checkmarx-plugin/pull/147)**

--------------------------------------------------------------------------------------------------------------------------------

**1. [PLUG-806](https://checkmarx.atlassian.net/browse/PLUG-806): [Jenkins] First scan in pipeline should not show report(of previous scan) if scan is asynchronous.**

- CxScanBuilder.java
   Added a flag(generateAsyncReport), in case of asynchronous scan to check, if reports are ready or not, in case flag is false, report name is not generated and method generateHTMLReport() won't be called.

- CxScanResult.java
  Added method isEmptyReportAsync() to check the value returned by the method getHtmlReport(), according to the value returned by isEmptyReportAsync(), appropriate message is displayed on UI.

--------------------------------------------------------------------------------------------------------------------------------

- Reviewer Requests: **@chanducmc @ThokalSameer ** 

--------------------------------------------------------------------------------------------------------------------------------

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
