### PR TITLE
[Jenkins] Move async log to Create CxSAST Scan section (PLUG-2678)

### DIFF
--- a/src/main/java/com/checkmarx/jenkins/CxScanBuilder.java
+++ b/src/main/java/com/checkmarx/jenkins/CxScanBuilder.java
@@ -1173,14 +1173,13 @@ public class CxScanBuilder extends Builder implements SimpleBuildStep {
 			}
 		}
 
-		if (!descriptor.isAsyncHtmlRemoval() || config.getSynchronous()) {
-			log.info("Running in Asynchronous mode. Not waiting for scan to finish.");
-
-			if (generateAsyncReport) {
-				String reportName = generateHTMLReport(workspace, checkmarxBuildDir, config, scanResults);
-				cxScanResult.setHtmlReportName(reportName);
-			}
+		if (!descriptor.isAsyncHtmlRemoval() && !config.getSynchronous()) {
+		    if (generateAsyncReport) {
+		        String reportName = generateHTMLReport(workspace, checkmarxBuildDir, config, scanResults);
+		        cxScanResult.setHtmlReportName(reportName);
+		    }
 		}
+
         run.addAction(cxScanResult);
 			} catch (ConfigurationException e1) {
 				e1.printStackTrace();

--- a/src/main/java/com/checkmarx/jenkins/CxScanCallable.java
+++ b/src/main/java/com/checkmarx/jenkins/CxScanCallable.java
@@ -159,7 +159,10 @@ public class CxScanCallable implements FilePath.FileCallable<RemoteScanInfo>, Se
 
             createScanResults = delegator.initiateScan();
             results.add(createScanResults);
-
+            if (!config.getSynchronous()) {
+                log.info("Running in Asynchronous mode. Not waiting for scan to finish.");
+            }
+           
             if (rootLog != null) {
                 handler.flush();
                 rootLog.removeHandler(handler);


### PR DESCRIPTION
Move "Running in Asynchronous mode..." to the correct phase and tidy results path.
Log is now printed right after initiateScan() in CxScanCallable (under **Create CxSAST Scan**).
Verified: async → prints once; sync → not printed. Refs: PLUG-2678, PLUG-2255.
