### PR TITLE
JDK 25 Compatibility — Build Environment Modernization (Minimum JDK 21)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,63 @@
-# Checkmarx SAST plugin for Jenkins
+# Checkmarx SAST Plugin for Jenkins
 
 [![Build Status](https://jenkins.ci.cloudbees.com/job/plugins/job/checkmarx-plugin/badge/icon)](https://jenkins.ci.cloudbees.com/job/plugins/job/checkmarx-plugin/)
 
-For information about this plug-in check its [Wiki](https://wiki.jenkins-ci.org/display/JENKINS/Checkmarx+CxSAST+Plugin).
+For information about this plugin check its [Wiki](https://wiki.jenkins-ci.org/display/JENKINS/Checkmarx+CxSAST+Plugin).
+
+---
+
+## Requirements
+
+| Requirement | Minimum Version |
+|-------------|----------------|
+| Java | 21 |
+| Jenkins | 2.541.1 |
+| Gradle (build only) | 8.14 |
+
+> **Note:** Java 17 support in Jenkins ends on or after March 31, 2026. This plugin requires Java 21 or higher.
+
+---
+
+## Java Version Compatibility
+
+| Java Version| Build         | Runtime (Jenkins) |
+|-------------|---------      |-------------------|
+| Java 8/11/17| Not supported | Not supported |
+| Java 21     | Supported     | Supported |
+| Java 25     | Not supported | Supported |
+
+---
+
+## Building from Source
+
+Ensure `JAVA_HOME` is set to a JDK 21 before building.
+
+```bash
+./gradlew clean build jpi
+```
+
+The built plugin will be available at:
+
+```
+build/libs/checkmarx.hpi
+```
+
+---
+
+## Running Tests
+
+```bash
+./gradlew test
+```
+
+---
+
+## Installation
+
+1. Go to **Jenkins > Manage Jenkins > Plugins > Advanced**
+2. Under **Deploy Plugin**, upload the `checkmarx.hpi` file
+3. Restart Jenkins
+
+---
+
 

--- a/build.gradle
+++ b/build.gradle
@@ -2,35 +2,40 @@ buildscript {
     repositories {
     	mavenCentral()
     	maven { url 'https://repo.jenkins-ci.org/public/' }
+        gradlePluginPortal()
     }
     dependencies {
-        classpath 'org.jenkins-ci.tools:gradle-jpi-plugin:0.35.0',
-                'com.netflix.nebula:gradle-extra-configurations-plugin:5.0.3'
+        classpath 'org.jenkins-ci.tools:gradle-jpi-plugin:0.55.2'
     }
 }
 
-plugins { id "no.nils.wsdl2java" version "0.8" }
-
 apply plugin: 'java'
+
+// Java 17 support in Jenkins ends March 31, 2026
+java {
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
+}
 apply plugin: 'idea'
 apply plugin: 'eclipse'
 apply plugin: 'project-report'
 apply plugin: 'org.jenkins-ci.jpi'
-apply plugin: 'nebula.provided-base'
 
-repositories {	
+repositories {
 	mavenCentral()
     mavenLocal()        // Use this to load a custom build of Common Client from a local Maven repo.
     maven { url 'https://repo.jenkins-ci.org/public/' }
-    maven { url 'http://cx-artifactory:8081/artifactory/libs-release/' }
-    maven { url 'http://cx-artifactory:8081/artifactory/libs-snapshot' }
-    maven { url 'http://cx-artifactory:8081/artifactory/plugins-release-local/' }
-    maven { url 'http://cx-artifactory:8081/artifactory/libs-snapshot-local' }
+    maven { url 'http://cx-artifactory:8081/artifactory/libs-release/'; allowInsecureProtocol = true }
+    maven { url 'http://cx-artifactory:8081/artifactory/libs-snapshot'; allowInsecureProtocol = true }
+    maven { url 'http://cx-artifactory:8081/artifactory/plugins-release-local/'; allowInsecureProtocol = true }
+    maven { url 'http://cx-artifactory:8081/artifactory/libs-snapshot-local'; allowInsecureProtocol = true }
 }
 
 test {
     maxParallelForks = Runtime.getRuntime().availableProcessors()
     useJUnitPlatform()
+    // Required for Mockito inline mocks on JDK 17+ where dynamic agent loading is restricted
+    jvmArgs '-XX:+EnableDynamicAgentLoading'
 }
 
 //currently there is an issue with Java8 and javadocs,
@@ -43,7 +48,7 @@ allprojects {
 dependencies {
     compileOnly 'com.intellij:annotations:12.0'
 
-    compile ('com.checkmarx:cx-config-provider:1.0.14') {
+    implementation ('com.checkmarx:cx-config-provider:1.0.14') {
         exclude group: 'org.slf4j', module: 'slf4j-api'
         exclude group: 'org.apache.logging.log4j', module: 'log4j-slf4j-impl'
         exclude group: 'org.apache.logging.log4j', module: 'log4j-api'
@@ -55,7 +60,7 @@ dependencies {
     }
 
 
-     compile ('com.checkmarx:cx-client-common:2025.4.40') {
+     implementation ('com.checkmarx:cx-client-common:2025.4.40') {
        
        exclude group: 'org.yaml' , module: 'snakeyaml'
        exclude group: 'com.google.code.gson', module: 'gson'
@@ -83,10 +88,10 @@ dependencies {
         exclude group: 'org.apache.velocity', module: 'velocity-engine-core'
        exclude group: 'org.codehaus.plexus', module: 'plexus-utils' 
     }
-    compile ('org.apache.velocity:velocity-engine-core:2.4') {
+    implementation ('org.apache.velocity:velocity-engine-core:2.4') {
         exclude group: 'commons-io', module: 'commons-io'
     }
-    compile  'com.fasterxml.jackson.core:jackson-core:2.11.3',
+    implementation  'com.fasterxml.jackson.core:jackson-core:2.11.3',
             'com.fasterxml.jackson.core:jackson-annotations:2.11.3',
             'com.fasterxml.jackson.core:jackson-databind:2.14.1',
             'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.11.3',
@@ -139,11 +144,18 @@ dependencies {
                 }
             }
 
-    optionalJenkinsPlugins 'org.jenkins-ci.main:maven-plugin:1.509.4@jar',
-    		'org.jenkins-ci.plugins:credentials:2.1.19@jar'
+    compileOnly 'org.jenkins-ci.main:maven-plugin:1.509.4@jar'
+    compileOnly 'org.jenkins-ci.plugins:credentials:2.1.19@jar'
+    testImplementation 'org.jenkins-ci.plugins:credentials:2.1.19@jar'
+
+    optionalJenkinsPlugins 'org.jenkins-ci.main:maven-plugin:1.509.4@jar'
+
+    // credentials is a required plugin dependency - declared as implementation so JPI 0.55.2
+    // generates Plugin-Dependencies in MANIFEST.MF (jenkinsPlugins config removed in JPI 0.50+)
+    implementation 'org.jenkins-ci.plugins:credentials:2.1.19'
 
 	
-    testCompile  'junit:junit:4.13.1',
+    testImplementation  'junit:junit:4.13.1',
             'org.eclipse.sisu:org.eclipse.sisu.plexus:0.0.0.M5',
             'org.jmockit:jmockit:1.16'
 
@@ -153,14 +165,20 @@ dependencies {
             'org.jenkins-ci.plugins:mailer:1.32.1@jar',
             'org.jenkins-ci.plugins:matrix-project:1.18@jar'
 
-    testImplementation('org.junit.jupiter:junit-jupiter-api:5.4.2',
-            'org.mockito:mockito-junit-jupiter:2.23.0')
-    testRuntime('org.junit.jupiter:junit-jupiter-engine:5.4.2',
-            'org.mockito:mockito-junit-jupiter:2.23.0')
+    testImplementation('org.junit.jupiter:junit-jupiter-api:5.10.2',
+            'org.mockito:mockito-junit-jupiter:5.10.0')
+    testRuntimeOnly('org.junit.jupiter:junit-jupiter-engine:5.10.2')
+    testRuntimeOnly('org.junit.platform:junit-platform-launcher:1.10.2')
 }
+// Gradle 8 requires explicit duplicate handling strategy for War/JPI packaging.
+// Old Gradle silently excluded duplicates; this maintains the same behavior.
+tasks.named('jpi') {
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+}
+
 jenkinsPlugin {
     // version of Jenkins core this plugin depends on
-    coreVersion = '2.77'
+    coreVersion = '2.541.1'
 
     // short name of the plugin, defaults to the project name without trailing '-plugin'
     shortName = 'checkmarx'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 description = Provides automatic scan of code by Checkmarx server and shows results summary and trend in Jenkins interface.
 group = com.checkmarx.jenkins
-version = 2025.4.1
+version = 2026.1.1
 
 repositoryVersion=
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
During investigation of PLUG-2799, it was found that the existing plugin version 2025.4.1 already runs on Jenkins with JDK 17, 21, and 25 without any issues. The actual gap identified was on the build side — the plugin source code could only be built using JDK 8 due to outdated build tooling (Gradle 4.10.2, Jenkins core 2.77, JPI plugin 0.35.0).

This PR modernizes the build environment to support minimum JDK 21 for building the plugin from source, which aligns with the Jenkins Java support policy (Java 17 EOL: March 31, 2026).

**Changes in this PR are intentionally scoped for future activation when the following requirement is formally raised:**

"The plugin must be buildable on minimum JDK 21 in CI/CD pipelines."

What was changed:

Gradle wrapper upgraded from 4.10.2 → 8.14
Jenkins core upgraded from 2.77 → 2.541.1 (first LTS with official JDK 25 support)
Gradle JPI plugin upgraded from 0.35.0 → 0.55.2
Deprecated compile/testCompile/testRuntime → implementation/testImplementation/testRuntimeOnly
JUnit upgraded from 5.4.2 → 5.10.2, Mockito from 2.23.0 → 5.10.0
Minimum Java version enforced to JDK 21 (sourceCompatibility = VERSION_21)
Credentials plugin dependency fixed to generate correct MANIFEST.MF
Removed dead dependencies (nebula, wsdl2java)
Testing done:

Build on JDK 21 — PASS
All existing tests — PASS
Plugin install on Jenkins JDK 21 — PASS
Plugin install on Jenkins JDK 25 — PASS
Plugin correctly blocked on Jenkins JDK 17 — PASS (intentional, per Jenkins EOL policy)

**Note for reviewer:**
These changes are ready to merge whenever the team formally requires JDK 21 as the minimum build environment. No source code (Java files) were modified — only build configuration was updated. Zero regressions observed.