### PR TITLE
Support hostname verification via Jenkins Global Properties

### DIFF
--- a/src/main/java/com/checkmarx/jenkins/CxScanBuilder.java
+++ b/src/main/java/com/checkmarx/jenkins/CxScanBuilder.java
@@ -1601,6 +1601,17 @@ public class CxScanBuilder extends Builder implements SimpleBuildStep {
         	ret.setPostScanActionId(getPostScanActionId());
         	
         ret.setDisableCertificateValidation(!descriptor.isEnableCertificateValidation());
+
+        // Read hostname verification settings from Jenkins environment
+        String hostnameVerificationEnv = env.get("CX_HOSTNAME_VERIFICATION_ENABLED");
+        if (hostnameVerificationEnv != null && !hostnameVerificationEnv.trim().isEmpty()) {
+            ret.setHostnameVerificationEnabled(Boolean.parseBoolean(hostnameVerificationEnv.trim()));
+        }
+        String allowedHostsEnv = env.get("CX_ALLOWED_HOSTS");
+        if (allowedHostsEnv != null && !allowedHostsEnv.trim().isEmpty()) {
+            ret.setAllowedHostname(allowedHostsEnv.trim());
+        }
+
         ret.setMvnPath(descriptor.getMvnPath());
         ret.setOsaGenerateJsonReport(false);
         


### PR DESCRIPTION
 Read CX_HOSTNAME_VERIFICATION_ENABLED and CX_ALLOWED_HOSTS from
  Jenkins build environment in resolveConfiguration() and pass to
  cx-client-common via CxScanConfig.